### PR TITLE
refactor: move inline styles to CSS classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
           </div>
         </div>
 
-        <h2 style="margin-top:10px">2) Thông tin bất động sản (phường/xã mới)</h2>
+          <h2 class="section-spacing">2) Thông tin bất động sản (phường/xã mới)</h2>
 
         <div class="grid-3">
           <div class="form-group">
@@ -88,7 +88,7 @@
           <div class="form-group">
             <label for="bd-ward">Phường/Xã (mới)</label>
             <select id="bd-ward"></select>
-            <div id="ward-custom-wrap" style="display:none;margin-top:6px">
+              <div id="ward-custom-wrap" class="ward-custom">
               <input type="text" id="bd-ward-custom" placeholder="Nhập tên phường/xã (khi chọn 'Khác')">
               <button id="btn-save-ward" class="secondary" type="button">Lưu phường vào danh sách</button>
             </div>
@@ -136,7 +136,7 @@
         </div>
         <div id="issues-container" class="issues-grid"></div>
 
-        <h2 style="margin-top:10px">3) La bàn số</h2>
+          <h2 class="section-spacing">3) La bàn số</h2>
         <div class="compass-wrap">
           <div class="compass">
             <div class="dial"></div>
@@ -158,7 +158,7 @@
           </div>
         </div>
 
-        <div class="actions" style="margin-top:14px;">
+          <div class="actions action-bar">
           <button id="btn-analyze">Phân tích phong thủy</button>
           <button id="btn-save" class="secondary">Lưu hồ sơ</button>
           <button id="btn-export" class="secondary">Xuất CSV</button>

--- a/style.css
+++ b/style.css
@@ -22,6 +22,9 @@ header .subtitle{color:var(--muted);font-size:0.95rem}
 }
 
 .actions{display:flex;gap:10px;flex-wrap:wrap}
+.section-spacing{margin-top:10px}
+.ward-custom{display:none;margin-top:6px}
+.action-bar{margin-top:14px}
 button#btn-analyze,.secondary{padding:12px 16px;border-radius:10px;border:0;cursor:pointer;font-weight:700}
 button#btn-analyze{background:linear-gradient(90deg,var(--secondary),var(--primary));color:#fff;box-shadow:0 10px 20px rgba(47,128,237,.25)}
 .secondary{background:#eef5ff;color:var(--primary)}


### PR DESCRIPTION
## Summary
- add `section-spacing`, `ward-custom`, and `action-bar` classes to consolidate margin and visibility styles
- replace inline styles in `index.html` with the new CSS classes

## Testing
- `npm test` *(fails: could not read package.json)*
- `rg 'style"' -n index.html`


------
https://chatgpt.com/codex/tasks/task_b_689a46e2d0f08323b7d97e8030156600